### PR TITLE
Flert

### DIFF
--- a/meddocan/data/containers.py
+++ b/meddocan/data/containers.py
@@ -165,9 +165,9 @@ class BratAnnotations(Sized):
         # TODO Talks about the BOM (Byte Ordering Mark). Cf: Fluent Python.
         # Some file contains the BOM and other not. If we remove the BOM
         # Manually or reading file with ``UTF-8-SIG`` encoding, with have
-        # missalignment between the spans and the text entities. This suggest
+        # misalignment between the spans and the text entities. This suggest
         # that the annotations process has been saved on file with BOM.
-        # A solution is to remove the BOM manually when writting file or remove
+        # A solution is to remove the BOM manually when writing file or remove
         # 1 to all the offsets in the corresponding brat_span.
 
         text = brat_files_pair.txt.read_text(encoding="utf-8")

--- a/meddocan/data/corpus.py
+++ b/meddocan/data/corpus.py
@@ -27,10 +27,17 @@ class MEDDOCAN(ColumnCorpus):
             Defaults to False.
         in_memory (bool, optional): Keep the data into memory or not.  
             Defaults to True.
+        document_separator_token (str = optional): Separate each document by
+            new line for `Flert` architecture. Usually *-DOCSTART-* in `FLair`.
+            Defaults to None.
     """
 
     def __init__(
-        self, sentences: bool = False, in_memory: bool = True, **corpusargs
+        self,
+        sentences: bool = False,
+        in_memory: bool = True,
+        document_separator_token: str = None,
+        **corpusargs,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdirname:
             for data_pth in (
@@ -44,7 +51,9 @@ class MEDDOCAN(ColumnCorpus):
                 output_pth: Path = Path(tmpdirname) / data_pth.value
                 brat_docs = GsDocs(archive_name=data_pth)
                 brat_docs.to_connl03(
-                    file=output_pth, write_sentences=sentences
+                    file=output_pth,
+                    write_sentences=sentences,
+                    document_separator_token=document_separator_token,
                 )
 
             # Column format.

--- a/meddocan/data/corpus.py
+++ b/meddocan/data/corpus.py
@@ -67,6 +67,7 @@ class MEDDOCAN(ColumnCorpus):
                 column_format=columns,
                 tag_to_bioes="ner",
                 in_memory=in_memory,
+                document_separator_token=document_separator_token,
                 **corpusargs,
             )
 

--- a/meddocan/data/docs_iterators.py
+++ b/meddocan/data/docs_iterators.py
@@ -233,8 +233,8 @@ doc=Datos del ...)
             write_sentences (bool, optional): If True, write each file new line
                 as a `Flair` sentence. If False, glue all the lines of the file
                 as a unique `Flair`sentence. Defaults to True.
-        document_separator_token (str = optional): Separate each document by
-            new line for `Flert` architecture. Defaults to None.
+            document_separator_token (str = optional): Separate each document
+                by new line for `Flert` architecture. Defaults to None.
         """
         for i, gs_doc in enumerate(self):
             (mode := "a") if i else (mode := "w")

--- a/meddocan/data/docs_iterators.py
+++ b/meddocan/data/docs_iterators.py
@@ -192,7 +192,10 @@ doc=Datos del ...)
             logger.info("\n")
 
     def to_connl03(
-        self, file: Union[str, Path], write_sentences: bool = True
+        self,
+        file: Union[str, Path],
+        write_sentences: bool = True,
+        document_separator_token: str = None,
     ) -> None:
         """Method that write the file contains in archive_name arguments to
         the given file at the ConNL03 format.
@@ -227,12 +230,19 @@ doc=Datos del ...)
 
         Args:
             file (Union[str, Path]): _description_
-            write_sentences (bool, optional): _description_. Defaults to True.
+            write_sentences (bool, optional): If True, write each file new line
+                as a `Flair` sentence. If False, glue all the lines of the file
+                as a unique `Flair`sentence. Defaults to True.
+        document_separator_token (str = optional): Separate each document by
+            new line for `Flert` architecture. Defaults to None.
         """
         for i, gs_doc in enumerate(self):
             (mode := "a") if i else (mode := "w")
             gs_doc.doc._.to_connl03(
-                file, mode=mode, write_sentences=write_sentences
+                file,
+                mode=mode,
+                write_sentences=write_sentences,
+                document_separator_token=document_separator_token,
             )
 
     def to_gold_standard(self, parent: Union[str, Path]) -> None:

--- a/meddocan/language/method_extensions.py
+++ b/meddocan/language/method_extensions.py
@@ -62,6 +62,7 @@ class WriteMethods:
         file: Union[str, Path],
         mode: Literal["w", "a"] = "w",
         write_sentences: bool = True,
+        document_separator_token: str = None,
     ) -> None:
         # ----------- Write a Doc to the given file at the CoNLL03 format.
         if isinstance(file, str):
@@ -99,7 +100,7 @@ class WriteMethods:
                 if write_sentences:
                     line = "\n"
                 else:
-                    line = "\\n O"
+                    line = "\\n O\n"
                 lines.append(line)
 
             if write_sentences:
@@ -107,6 +108,9 @@ class WriteMethods:
             else:
                 joined_lines = "".join((*lines, "\n"))
                 f.write(joined_lines)
+            if document_separator_token is not None:
+                document_separator_line = f"{document_separator_token} O\n\n"
+                f.write(document_separator_line)
 
     @staticmethod
     def __doc_to_ann(doc: Doc, file: Union[str, Path]) -> None:

--- a/meddocan/language/method_extensions.py
+++ b/meddocan/language/method_extensions.py
@@ -64,7 +64,7 @@ class WriteMethods:
         write_sentences: bool = True,
         document_separator_token: Optional[str] = None,
     ) -> None:
-        # ----------- Write a Doc to the given file at the CoNLL03 format.
+        # ----------- Write a Doc to the given file at the CoNNL03 format.
         if isinstance(file, str):
             file = Path(file)
 

--- a/meddocan/language/method_extensions.py
+++ b/meddocan/language/method_extensions.py
@@ -114,8 +114,7 @@ class WriteMethods:
 
     @staticmethod
     def __doc_to_ann(doc: Doc, file: Union[str, Path]) -> None:
-        # To avoid circular import
-        from meddocan.data.utils import doc_to_ann
+        from meddocan.data.utils import doc_to_ann  # To avoid circular import
 
         doc_to_ann(doc, file)
 

--- a/meddocan/language/method_extensions.py
+++ b/meddocan/language/method_extensions.py
@@ -19,7 +19,7 @@ found in the |spaCy| documentation `Creating custom pipeline components`_.
 """
 import codecs
 from pathlib import Path
-from typing import Callable, List, Literal, Union
+from typing import Callable, List, Literal, Optional, Union
 
 import spacy.tokens
 from spacy.language import Language
@@ -62,7 +62,7 @@ class WriteMethods:
         file: Union[str, Path],
         mode: Literal["w", "a"] = "w",
         write_sentences: bool = True,
-        document_separator_token: str = None,
+        document_separator_token: Optional[str] = None,
     ) -> None:
         # ----------- Write a Doc to the given file at the CoNLL03 format.
         if isinstance(file, str):

--- a/meddocan/language/method_extensions.py
+++ b/meddocan/language/method_extensions.py
@@ -89,6 +89,11 @@ class WriteMethods:
 
         with file.open(mode=mode, encoding="utf-8", newline="\n") as f:
             lines: List[str] = []
+
+            if document_separator_token is not None:
+                document_separator_line = f"{document_separator_token} O\n\n"
+                f.write(document_separator_line)
+
             for sent in doc.sents:
                 for token in sent:
                     if token.is_space:
@@ -108,9 +113,6 @@ class WriteMethods:
             else:
                 joined_lines = "".join((*lines, "\n"))
                 f.write(joined_lines)
-            if document_separator_token is not None:
-                document_separator_line = f"{document_separator_token} O\n\n"
-                f.write(document_separator_line)
 
     @staticmethod
     def __doc_to_ann(doc: Doc, file: Union[str, Path]) -> None:

--- a/meddocan/language/predictor.py
+++ b/meddocan/language/predictor.py
@@ -62,7 +62,7 @@ class PredictorComponent:
         Returns:
             flair.data.Sentence: The obtained Flair sentence.
         """
-        flair_sentence = flair.data.Sentence()
+        flair_sentence = flair.data.Sentence("")
         flair_sentence.language_code = "es"
         flair_sentence.start_pos = spacy_sentence.start_char
         flair_tokens: List[flair.data.Token] = []

--- a/tests/data/test_corpus.py
+++ b/tests/data/test_corpus.py
@@ -1,14 +1,17 @@
 """Module where we test that the MEDDOCAN corpus implementation is correct.
 """
+import logging
 from typing import List, Tuple, Union
 from unittest.mock import patch
 
 import pytest
-from flair.data import Sentence
+from flair.data import Label, Sentence, Span
 
 from meddocan.data.corpus import MEDDOCAN
 from meddocan.data.docs_iterators import GsDocs
 from tests.language.test_method_extensions import MockDoc, TokenElements
+
+logger = logging.getLogger("flair")
 
 
 class MockBratDocs:
@@ -19,11 +22,9 @@ class MockBratDocs:
 
     def __iter__(self):
         for a in self.docs:
-            print("inside __iter__")
             yield a.get_spacy_doc()
 
     def __call__(self):
-        print("inside call")
         return self.__iter__()
 
 
@@ -53,76 +54,106 @@ class TestMeddocan:
     """
 
     @pytest.mark.parametrize(
-        "docs, expected_contexts",
+        "docs",
+        (
+            [
+                MockDoc(
+                    [
+                        TokenElements("Vivo", True, True),
+                        TokenElements("en", True, False),
+                        TokenElements("Aix", False, False, "B-LOC"),
+                        TokenElements("!", True, False),
+                        TokenElements("Soy", True, True),
+                        TokenElements("Eric", True, False, "B-PERS"),
+                        TokenElements("Laffont", False, False, "I-PERS"),
+                        TokenElements(".", True, False),
+                    ],
+                ),
+                MockDoc(
+                    [
+                        TokenElements("Vivo", True, True),
+                        TokenElements("en", True, False),
+                        TokenElements("Bilbao", False, False, "B-LOC"),
+                        TokenElements("!", True, False),
+                        TokenElements("Soy", True, True),
+                        TokenElements("Zaira", True, False, "B-PERS"),
+                        TokenElements("Aurrekoetxea", False, False, "I-PERS"),
+                        TokenElements(".", True, False),
+                    ],
+                ),
+            ],
+        ),
+    )
+    @pytest.mark.parametrize(
+        "document_separator_token, expected_contexts",
         (
             (
+                "-DOCSTART-",
                 [
-                    MockDoc(
-                        [
-                            TokenElements("Vivo", True, True),
-                            TokenElements("en", True, False),
-                            TokenElements("Aix", False, False),
-                            TokenElements("!", True, False),
-                            TokenElements("Soy", True, True),
-                            TokenElements("Eric", True, False, "B-PERS"),
-                            TokenElements("Laffont", False, False, "I-PERS"),
-                            TokenElements(".", True, False),
-                        ],
+                    (
+                        [],
+                        "-DOCSTART-",
+                        ["Vivo", "en", "Aix", "!", "Soy", "Eric"],
+                        None,
                     ),
-                    MockDoc(
-                        [
-                            TokenElements("Vivo", True, True),
-                            TokenElements("en", True, False),
-                            TokenElements("Bilbao", False, False),
-                            TokenElements("!", True, False),
-                            TokenElements("Soy", True, True),
-                            TokenElements("Zaira", True, False, "B-PERS"),
-                            TokenElements(
-                                "Aurrekoetxea", False, False, "I-PERS"
-                            ),
-                            TokenElements(".", True, False),
-                        ],
+                    (
+                        [],
+                        "Vivo en Aix !",
+                        ["Soy", "Eric", "Laffont", "."],
+                        (2, 3, "LOC"),
+                    ),
+                    (
+                        ["Vivo", "en", "Aix", "!"],
+                        "Soy Eric Laffont .",
+                        [],
+                        (1, 3, "PERS"),
+                    ),
+                    (
+                        ["Aix", "!", "Soy", "Eric", "Laffont", "."],
+                        "-DOCSTART-",
+                        ["Vivo", "en", "Bilbao", "!", "Soy", "Zaira"],
+                        None,
+                    ),
+                    (
+                        [],
+                        "Vivo en Bilbao !",
+                        ["Soy", "Zaira", "Aurrekoetxea", "."],
+                        (2, 3, "LOC"),
+                    ),
+                    (
+                        ["Vivo", "en", "Bilbao", "!"],
+                        "Soy Zaira Aurrekoetxea .",
+                        [],
+                        (1, 3, "PERS"),
                     ),
                 ],
+            ),
+            (
+                None,
                 [
-                    ([], ["Soy", "Eric", "Laffont", "."]),
-                    (["Vivo", "en", "Aix", "!"], []),
                     (
-                        [
-                            "Vivo",
-                            "en",
-                            "Aix",
-                            "!",
-                            "Soy",
-                            "Eric",
-                            "Laffont",
-                            ".",
-                        ],
-                        [
-                            "Vivo",
-                            "en",
-                            "Bilbao",
-                            "!",
-                            "Soy",
-                            "Zaira",
-                            "Aurrekoetxea",
-                            ".",
-                        ],
-                    ),
-                    ([], ["Soy", "Zaira", "Aurrekoetxea", "."]),
-                    (["Vivo", "en", "Bilbao", "!"], []),
-                    (
-                        [
-                            "Vivo",
-                            "en",
-                            "Bilbao",
-                            "!",
-                            "Soy",
-                            "Zaira",
-                            "Aurrekoetxea",
-                            ".",
-                        ],
                         [],
+                        "Vivo en Aix !",
+                        ["Soy", "Eric", "Laffont", ".", "Vivo", "en"],
+                        (2, 3, "LOC"),
+                    ),
+                    (
+                        ["Vivo", "en", "Aix", "!"],
+                        "Soy Eric Laffont .",
+                        ["Vivo", "en", "Bilbao", "!", "Soy", "Zaira"],
+                        (1, 3, "PERS"),
+                    ),
+                    (
+                        ["Aix", "!", "Soy", "Eric", "Laffont", "."],
+                        "Vivo en Bilbao !",
+                        ["Soy", "Zaira", "Aurrekoetxea", "."],
+                        (2, 3, "LOC"),
+                    ),
+                    (
+                        ["Laffont", ".", "Vivo", "en", "Bilbao", "!"],
+                        "Soy Zaira Aurrekoetxea .",
+                        [],
+                        (1, 3, "PERS"),
                     ),
                 ],
             ),
@@ -131,36 +162,94 @@ class TestMeddocan:
     def test_init(
         self,
         docs: Union[List[MockDoc], MockDoc],
-        expected_contexts: List[Tuple[List[str], List[str]]],
+        document_separator_token: str,
+        expected_contexts: List[
+            Tuple[List[str], str, List[str], Tuple[int, int, str]]
+        ],
     ) -> None:
+        """Test that the MEDDOCAN corpus is implemented correctly.
+        To do that we mock the
+        :meth:`~meddocan.data.docs_iterators.GsDocs.__iter__` method of the
+        class :class:`~meddocan.data.docs_iterators.GsDocs`. This mocked |Doc|
+        is then internally copied to a temporary file by the custom
+        :meth:`~meddocan.language.method_extensions.WriteMethods.__doc_to_connl03`
+        of the Doc object. This is possible because the ``meddocan`` language
+        set the |Doc| extensions `to_connl03` and thus allow to use it on the
+        mocked documents.
+
+        Args:
+            docs (Union[List[MockDoc], MockDoc]): The documents retrieve by
+                the mocked `__iter__` method.
+            document_separator_token (str): Document separator argument for the
+                :class:`~meddocan.data.corpus.MEDDOCAN` corpus.
+            expected_contexts (
+                List[ Tuple[List[str], str, List[str], Tuple[int, int, str]] ]
+                ): The expected contexts. A tuple made of the following parts:
+                (Left context, tokenized sentence as str, right context, label)
+
+                THe chosen context size is of 6 tokens.
+
+                For Example:
+
+                >>> expected_contexts = (
+                ... ["Me", "llamo", Bertrand", "."],
+                ... "Vivo en Aix .",
+                ... ["Es", "una", "ciudad", "bonita", "."],
+                ... (2, 3, "LOC"),
+                ... ]
+        """
         with patch.object(
             GsDocs, "__iter__", new_callable=lambda: MockBratDocs(docs)
         ):
             # Cf: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
             # nonlocal expected
             meddocan = MEDDOCAN(
-                sentences=True, document_separator_token="-DOCSTART-"
+                sentences=True,
+                document_separator_token=document_separator_token,
             )
             sentence: Sentence
-            for sentence, (left_context, right_context) in zip(
-                meddocan.train, expected_contexts
-            ):
-                assert sentence.left_context(64) == left_context
-                assert sentence.right_context(64) == right_context
+            for sentence, (
+                left_context,
+                expected_sentence,
+                right_context,
+                entity,
+            ) in zip(meddocan.train, expected_contexts):
+
+                # Construct Label from expected_contexts
+
+                labels: List[Label] = []
+                if entity is not None:
+                    span = Span(sentence.tokens[entity[0] : entity[1]])
+                    labels.append(Label(span, value=entity[2]))
+
+                assert sentence.to_original_text() == expected_sentence
+                assert sentence.left_context(6) == left_context
+                assert sentence.right_context(6) == right_context
+                assert sentence.get_labels() == labels
 
 
 if __name__ == "__main__":
-    TestMeddocan().test_init()
+    # TestMeddocan().test_init()
+    from flair.data import Sentence
 
-    # from flair.datasets import CONLL_03, CONLL_03_SPANISH
-    # from flair.data import Sentence
-    # from meddocan import cache_root
-    #
-    # corpus = CONLL_03(cache_root / "datasets")
+    sentence = Sentence("Vivo en Aix!")
+    print(
+        sentence.to_original_text(),
+        [token.start_position for token in sentence],
+    )
+
+    from flair.data import Sentence
+    from flair.datasets import CONLL_03
+
+    from meddocan import cache_root
+
+    corpus = CONLL_03(cache_root / "datasets")
     # corpus = CONLL_03_SPANISH()
-    # sentence: Sentence
-    # for i, sentence in enumerate(corpus.train):
-    #     if i < 10:
-    #         print("\t", sentence, " ".join(sentence.left_context(64)), " ".join(sentence.right_context(64)))
-    #     else:
-    #         break
+    sentence: Sentence
+    for i, sentence in enumerate(corpus.train):
+        if i < 100:
+            print(sentence)
+            print("\t", " ".join(sentence.left_context(4)))
+            print("\t", " ".join(sentence.right_context(4)))
+        else:
+            break

--- a/tests/data/test_corpus.py
+++ b/tests/data/test_corpus.py
@@ -1,0 +1,169 @@
+from turtle import right
+from typing import List, Iterator, Tuple, Union
+from unittest.mock import patch, Mock
+import pytest
+
+from flair.data import Sentence
+
+from meddocan.data.corpus import MEDDOCAN
+from tests.language.test_method_extensions import MockDoc, TokenElements
+
+from meddocan.data.docs_iterators import (
+    GsDocs,
+    BratFilesPair,
+    DocWithBratPair,
+    GsDoc,
+)
+
+
+class MockBratDocs:
+    def __init__(self, docs: Union[List[MockDoc], MockDoc]) -> None:
+        if isinstance(docs, MockDoc):
+            docs = [docs]
+        self.docs = docs
+
+    def __iter__(self):
+        for a in self.docs:
+            print("inside __iter__")
+            yield a.get_spacy_doc()
+
+    def __call__(self):
+        print("inside call")
+        return self.__iter__()
+
+
+class TestMeddocan:
+    """
+
+    An example of how we can test this class:
+    Cf: https://docs.python.org/3/library/unittest.mock.html#patch
+
+        >>> from unittest.mock import patch
+        >>> class Class:
+        ...     def __iter__(self):
+        ...         for a in [1, 2, 3]:
+        ...             yield a
+        ...
+        >>> def function():
+        ...     return sum(a for a in Class())
+        ...
+        >>> with patch("__main__.Class") as MockClass:
+        ...     instance = MockClass.return_value
+        ...     instance.__iter__.return_value = [1, 2, 3]
+        ...     assert Class() is instance
+        ...     assert [a for a in Class()] == [1, 2, 3]
+        ...     assert function() == 6
+    """
+
+    @pytest.mark.parametrize(
+        "docs, expected_contexts",
+        (
+            (
+                [
+                    MockDoc(
+                        [
+                            TokenElements("Vivo", True, True),
+                            TokenElements("en", True, False),
+                            TokenElements("Aix", False, False),
+                            TokenElements("!", True, False),
+                            TokenElements("Soy", True, True),
+                            TokenElements("Eric", True, False, "B-PERS"),
+                            TokenElements("Laffont", False, False, "I-PERS"),
+                            TokenElements(".", True, False),
+                        ],
+                    ),
+                    MockDoc(
+                        [
+                            TokenElements("Vivo", True, True),
+                            TokenElements("en", True, False),
+                            TokenElements("Bilbao", False, False),
+                            TokenElements("!", True, False),
+                            TokenElements("Soy", True, True),
+                            TokenElements("Zaira", True, False, "B-PERS"),
+                            TokenElements(
+                                "Aurrekoetxea", False, False, "I-PERS"
+                            ),
+                            TokenElements(".", True, False),
+                        ],
+                    ),
+                ],
+                [
+                    ([], ["Soy", "Eric", "Laffont", "."]),
+                    (["Vivo", "en", "Aix", "!"], []),
+                    (
+                        [
+                            "Vivo",
+                            "en",
+                            "Aix",
+                            "!",
+                            "Soy",
+                            "Eric",
+                            "Laffont",
+                            ".",
+                        ],
+                        [
+                            "Vivo",
+                            "en",
+                            "Bilbao",
+                            "!",
+                            "Soy",
+                            "Zaira",
+                            "Aurrekoetxea",
+                            ".",
+                        ],
+                    ),
+                    ([], ["Soy", "Zaira", "Aurrekoetxea", "."]),
+                    (["Vivo", "en", "Bilbao", "!"], []),
+                    (
+                        [
+                            "Vivo",
+                            "en",
+                            "Bilbao",
+                            "!",
+                            "Soy",
+                            "Zaira",
+                            "Aurrekoetxea",
+                            ".",
+                        ],
+                        [],
+                    ),
+                ],
+            ),
+        ),
+    )
+    def test_init(
+        self,
+        docs: Union[List[MockDoc], MockDoc],
+        expected_contexts: List[Tuple[List[str], List[str]]],
+    ) -> None:
+        with patch.object(
+            GsDocs, "__iter__", new_callable=lambda: MockBratDocs(docs)
+        ):
+            # Cf: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+            # nonlocal expected
+            meddocan = MEDDOCAN(
+                sentences=True, document_separator_token="-DOCSTART-"
+            )
+            sentence: Sentence
+            for sentence, (left_context, right_context) in zip(
+                meddocan.train, expected_contexts
+            ):
+                assert sentence.left_context(64) == left_context
+                assert sentence.right_context(64) == right_context
+
+
+if __name__ == "__main__":
+    TestMeddocan().test_init()
+
+    # from flair.datasets import CONLL_03, CONLL_03_SPANISH
+    # from flair.data import Sentence
+    # from meddocan import cache_root
+    #
+    # corpus = CONLL_03(cache_root / "datasets")
+    # corpus = CONLL_03_SPANISH()
+    # sentence: Sentence
+    # for i, sentence in enumerate(corpus.train):
+    #     if i < 10:
+    #         print("\t", sentence, " ".join(sentence.left_context(64)), " ".join(sentence.right_context(64)))
+    #     else:
+    #         break

--- a/tests/data/test_corpus.py
+++ b/tests/data/test_corpus.py
@@ -1,19 +1,14 @@
-from turtle import right
-from typing import List, Iterator, Tuple, Union
-from unittest.mock import patch, Mock
-import pytest
+"""Module where we test that the MEDDOCAN corpus implementation is correct.
+"""
+from typing import List, Tuple, Union
+from unittest.mock import patch
 
+import pytest
 from flair.data import Sentence
 
 from meddocan.data.corpus import MEDDOCAN
+from meddocan.data.docs_iterators import GsDocs
 from tests.language.test_method_extensions import MockDoc, TokenElements
-
-from meddocan.data.docs_iterators import (
-    GsDocs,
-    BratFilesPair,
-    DocWithBratPair,
-    GsDoc,
-)
 
 
 class MockBratDocs:
@@ -33,7 +28,9 @@ class MockBratDocs:
 
 
 class TestMeddocan:
-    """
+    """In order to test if the corpus is implemented correctly,
+    we look at the ``flair.data.Sentence.left_context`` and
+    ``flair.data.Sentence.right_context`` output.
 
     An example of how we can test this class:
     Cf: https://docs.python.org/3/library/unittest.mock.html#patch

--- a/tests/language/test_method_extensions.py
+++ b/tests/language/test_method_extensions.py
@@ -1,0 +1,229 @@
+"""This module contains the tests done to validate the functionality of the
+:class:`WriteMethods` and particularly the ability to write a
+``spacy.tokens.Doc`` in a file at the *IOB* format.
+"""
+from __future__ import annotations
+
+import itertools as it
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple
+from unittest.mock import call, mock_open, patch
+
+import pytest
+from spacy.tokens import Doc
+from spacy.vocab import Vocab
+
+from meddocan.language.method_extensions import WriteMethods
+
+
+@dataclass
+class TokenElements:
+    word: str
+    space: Optional[bool] = False
+    sent_start: bool = False
+    iob: str = "O"
+
+
+@dataclass
+class DocElements:
+    tokens: Optional[List[TokenElements]]
+    """``spacy.tokens.Doc`` raw tokens attribute"""
+
+    def get_spacy_doc(self) -> Doc:
+        """Create a ``spacy.tokens.Doc``.
+
+        Returns:
+            Doc: The doc created from ``DocElements.tokens``attribute.
+        """
+        if self.tokens is not None:
+            words = [t.word for t in self.tokens]
+            return Doc(
+                Vocab(strings=words),
+                words=words,
+                spaces=[t.space for t in self.tokens],
+                sent_starts=[t.sent_start for t in self.tokens],
+                ents=[t.iob for t in self.tokens],
+            )
+        else:
+            return Doc()
+
+
+class TestDocElements:
+    """Test :class:`DocElements`."""
+
+    @pytest.mark.parametrize(
+        argnames="tokens, expected_text, expected_sents, expected_ents",
+        argvalues=(
+            (
+                [
+                    TokenElements("Me", True, True),
+                    TokenElements("llamo", True, False),
+                    TokenElements("Pedro", True, False, "B-PERS"),
+                    TokenElements("Fuerte", False, False, "I-PERS"),
+                    TokenElements("!", True, False),
+                    TokenElements("Vivo", True, True),
+                    TokenElements("en", True, False),
+                    TokenElements("Salamanca", False, False, "B-LOC"),
+                    TokenElements(".", False, False),
+                ],
+                "Me llamo Pedro Fuerte! Vivo en Salamanca.",
+                ("Me llamo Pedro Fuerte!", "Vivo en Salamanca."),
+                ("Pedro Fuerte", "Salamanca"),
+            ),
+            ([TokenElements("Bilbao")], "Bilbao", ("Bilbao",), None),
+            (
+                [TokenElements("Bilbao", iob="B-LOC")],
+                "Bilbao",
+                ("Bilbao",),
+                ("Bilbao",),
+            ),
+        ),
+    )
+    def test_get_doc(
+        self,
+        tokens: List[TokenElements],
+        expected_text: str,
+        expected_sents: Optional[Tuple[str, ...]],
+        expected_ents: Optional[Tuple[str, ...]],
+    ) -> None:
+
+        if expected_sents is None:
+            expected_sents = []
+
+        if expected_ents is None:
+            expected_ents = []
+
+        doc = DocElements(tokens).get_spacy_doc()
+
+        # text spaces and str are rendered correctly
+        assert doc.text == expected_text
+
+        # sentences are correct
+        for found_sent, expected_sent in it.zip_longest(
+            doc.sents, expected_sents
+        ):
+            assert found_sent.text == expected_sent
+
+        # entities are correct
+        for found_ent, expected_ent in it.zip_longest(doc.ents, expected_ents):
+            assert found_ent.text == expected_ent
+
+
+class TestWriteMethods:
+    @pytest.mark.parametrize(
+        "tokens",
+        (
+            [
+                TokenElements("Me", True, True),
+                TokenElements("llamo", True, False),
+                TokenElements("Pedro", True, False, "B-PERS"),
+                TokenElements("Fuerte", False, False, "I-PERS"),
+                TokenElements("!", True, False),
+                TokenElements("Vivo", True, True),
+                TokenElements("en", True, False),
+                TokenElements("Salamanca", False, False, "B-LOC"),
+                TokenElements(".", False, False),
+            ],
+        ),
+    )
+    @pytest.mark.parametrize(
+        argnames="write_sentences, document_separator_token, mode, expected",
+        argvalues=(
+            (
+                True,
+                None,
+                "w",
+                (
+                    "Me O\n",
+                    "llamo O\n",
+                    "Pedro B-PERS\n",
+                    "Fuerte I-PERS\n",
+                    "! O\n",
+                    "\n",
+                    "Vivo O\n",
+                    "en O\n",
+                    "Salamanca B-LOC\n",
+                    ". O\n",
+                    "\n",
+                ),
+            ),
+            (
+                True,
+                "-DOCSTART-",
+                "w",
+                (
+                    "Me O\n",
+                    "llamo O\n",
+                    "Pedro B-PERS\n",
+                    "Fuerte I-PERS\n",
+                    "! O\n",
+                    "\n",
+                    "Vivo O\n",
+                    "en O\n",
+                    "Salamanca B-LOC\n",
+                    ". O\n",
+                    "\n",
+                ),
+            ),
+            (
+                False,
+                None,
+                "w",
+                (
+                    "Me O\nllamo O\nPedro B-PERS\nFuerte I-PERS\n!"
+                    " O\n\\n O\nVivo O\nen O\nSalamanca B-LOC\n. O\n\\n O\n\n"
+                ),
+            ),
+            (
+                False,
+                "-DOCSTART-",
+                "w",
+                (
+                    "Me O\nllamo O\nPedro B-PERS\nFuerte I-PERS\n!"
+                    " O\n\\n O\nVivo O\nen O\nSalamanca B-LOC\n. O\n\\n O\n\n"
+                ),
+            ),
+        ),
+    )
+    def test__doc_to_connl03_one_doc(
+        self,
+        tokens: List[TokenElements],
+        write_sentences: bool,
+        document_separator_token: Optional[str],
+        mode: Literal["w", "a"],
+        expected: Tuple(str, ...),
+    ) -> None:
+        # for doc in docs:
+
+        doc = DocElements(tokens).get_spacy_doc()
+
+        m = mock_open()
+        with patch("pathlib.Path.open", m):
+            WriteMethods._WriteMethods__doc_to_connl03(
+                doc,
+                file="file.tsv",
+                write_sentences=write_sentences,
+                document_separator_token=document_separator_token,
+            )
+        m.assert_called_once_with(mode="w", encoding="utf-8", newline="\n")
+
+        # Recuperate the calls made to the "writelines" method of the mock
+        # object.
+        handle = m()
+
+        # Verify that the written lines are the expected ones.
+        if write_sentences:
+            # Verify that writelines methods is call with the expected lines
+            assert handle.writelines.call_args == call(list(expected))
+            if document_separator_token is not None:
+                assert handle.write.call_args == call(
+                    f"{document_separator_token} O\n\n"
+                )
+        else:
+            if document_separator_token is not None:
+                assert handle.write.call_args_list == [
+                    call(expected),
+                    call(f"{document_separator_token} O\n\n"),
+                ]
+            else:
+                assert handle.write.call_args == call(expected)

--- a/tests/language/test_method_extensions.py
+++ b/tests/language/test_method_extensions.py
@@ -220,16 +220,16 @@ class TestWriteMethods:
         # Verify that the written lines are the expected ones.
         if write_sentences:
             # Verify that writelines methods is call with the expected lines
-            assert handle.writelines.call_args == call(list(expected))
             if document_separator_token is not None:
                 assert handle.write.call_args == call(
                     f"{document_separator_token} O\n\n"
                 )
+            assert handle.writelines.call_args == call(list(expected))
         else:
             if document_separator_token is not None:
                 assert handle.write.call_args_list == [
-                    call(expected),
                     call(f"{document_separator_token} O\n\n"),
+                    call(expected),
                 ]
             else:
                 assert handle.write.call_args == call(expected)

--- a/tests/language/test_method_extensions.py
+++ b/tests/language/test_method_extensions.py
@@ -25,7 +25,7 @@ class TokenElements:
 
 
 @dataclass
-class DocElements:
+class MockDoc:
     tokens: List[TokenElements]
     """``spacy.tokens.Doc`` raw tokens attribute"""
 
@@ -33,7 +33,7 @@ class DocElements:
         """Create a ``spacy.tokens.Doc``.
 
         Returns:
-            Doc: The doc created from ``DocElements.tokens``attribute.
+            Doc: The doc created from ``MockDoc.tokens``attribute.
         """
         words = [t.word for t in self.tokens]
 
@@ -50,8 +50,8 @@ class DocElements:
         )
 
 
-class TestDocElements:
-    """Test :class:`DocElements`."""
+class TestMockDoc:
+    """Test :class:`MockDoc`."""
 
     @pytest.mark.parametrize(
         argnames="tokens, expected_text, expected_sents, expected_ents",
@@ -101,21 +101,17 @@ class TestDocElements:
         if expected_ents is not None:
             _expected_ents = expected_ents
 
-        doc = DocElements(tokens).get_spacy_doc()
+        doc = MockDoc(tokens).get_spacy_doc()
 
         # text spaces and str are rendered correctly
         assert doc.text == expected_text
 
         # sentences are correct
-        for found_sent, expected_sent in it.zip_longest(
-            doc.sents, _expected_sents
-        ):
+        for found_sent, expected_sent in it.zip_longest(doc.sents, _expected_sents):
             assert found_sent.text == expected_sent
 
         # entities are correct
-        for found_ent, expected_ent in it.zip_longest(
-            doc.ents, _expected_ents
-        ):
+        for found_ent, expected_ent in it.zip_longest(doc.ents, _expected_ents):
             assert found_ent.text == expected_ent
 
 
@@ -201,7 +197,7 @@ class TestWriteMethods:
         expected: Tuple[str, ...],
     ) -> None:
 
-        doc = DocElements(tokens).get_spacy_doc()
+        doc = MockDoc(tokens).get_spacy_doc()
 
         m = mock_open()
         with patch("pathlib.Path.open", m):

--- a/tests/language/test_method_extensions.py
+++ b/tests/language/test_method_extensions.py
@@ -107,11 +107,15 @@ class TestMockDoc:
         assert doc.text == expected_text
 
         # sentences are correct
-        for found_sent, expected_sent in it.zip_longest(doc.sents, _expected_sents):
+        for found_sent, expected_sent in it.zip_longest(
+            doc.sents, _expected_sents
+        ):
             assert found_sent.text == expected_sent
 
         # entities are correct
-        for found_ent, expected_ent in it.zip_longest(doc.ents, _expected_ents):
+        for found_ent, expected_ent in it.zip_longest(
+            doc.ents, _expected_ents
+        ):
             assert found_ent.text == expected_ent
 
 


### PR DESCRIPTION
Add the `document_separator_token` option to `meddocan.data.corpus.MEDDOCAN` class.  

The goal is to use the `flair.embeddings.base.TransformerEmbedding` class to not create context on the right if an other document is detected.