### PR TITLE
Silent Flair warning went created empty sentence.

### DIFF
--- a/meddocan/language/logutils.py
+++ b/meddocan/language/logutils.py
@@ -1,0 +1,28 @@
+"""Copied from: https://gist.github.com/simon-weber/7853144"""
+import logging
+from contextlib import contextmanager
+
+
+@contextmanager
+def all_logging_disabled(highest_level: int = logging.CRITICAL):
+    """A context manager that will prevent any logging messages
+    triggered during the body from being processed.
+
+    Args:
+        highest_level (int, optional): the maximum logging level in use.
+            This would only need to be changed if a custom level greater than
+            CRITICAL is defined. Defaults to logging.CRITICAL.
+    """
+    # two kind-of hacks here:
+    #   * can't get the highest logging level in effect => delegate to the user
+    #   * can't get the current module-level override => use an undocumented
+    #       (but non-private!) interface
+
+    previous_level = logging.root.manager.disable
+
+    logging.disable(highest_level)
+
+    try:
+        yield
+    finally:
+        logging.disable(previous_level)

--- a/meddocan/language/predictor.py
+++ b/meddocan/language/predictor.py
@@ -5,12 +5,15 @@ Look the spaCy `stateful components`_ example for more information.
 
 .. _stateful components: https://spacy.io/usage/processing-pipelines#example-stateful-components
 """
+import logging
 from typing import Callable, List, Optional
 
 import flair.data
 from flair.models import SequenceTagger
 from spacy.language import Language
 from spacy.tokens import Doc, Span
+
+from meddocan.language.logutils import all_logging_disabled
 
 
 class PredictorComponent:
@@ -62,7 +65,8 @@ class PredictorComponent:
         Returns:
             flair.data.Sentence: The obtained Flair sentence.
         """
-        flair_sentence = flair.data.Sentence("")
+        with all_logging_disabled(logging.WARNING):
+            flair_sentence = flair.data.Sentence("")
         flair_sentence.language_code = "es"
         flair_sentence.start_pos = spacy_sentence.start_char
         flair_tokens: List[flair.data.Token] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ addopts = [
     "--numprocesses=auto",
     "-ra",
 ]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 filterwarnings = [
     "ignore::DeprecationWarning:scipy.*",
     "ignore::DeprecationWarning:past.*",

--- a/tests/language/test_logutils.py
+++ b/tests/language/test_logutils.py
@@ -1,0 +1,25 @@
+import logging
+
+import pytest
+
+from meddocan.language.logutils import all_logging_disabled
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(argnames="disable_log,", argvalues=[False, True])
+def test_all_logging_disabled(caplog, disable_log: bool):
+    """Test that the context manager all_logging_disabled is working as
+    expected.
+    """
+    # Cf: https://docs.pytest.org/en/7.1.x/how-to/logging.html
+    if disable_log:
+        with all_logging_disabled(highest_level=logging.INFO):
+            logger.info("hello")
+        assert caplog.record_tuples == []
+    else:
+        logger.info("hello")
+        assert caplog.record_tuples == [
+            ("test_logutils", logging.INFO, "hello")
+        ]


### PR DESCRIPTION
When we create a ``flair.data.Sentence`` object  this way:

```python
sentence = Sentence("")
```

Flair log the following warning to stdout:

```console
2022-09-02 08:10:47,040 Warning: An empty Sentence was created! Are there empty strings in your dataset?
```
In order to avoid this log, we can silent it just when we create the "empty" ``flair.data.Sentence`` in order to have a clean display when we use the meddocan pipeline predictor.